### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		43E970E62850272800FE5AE3 /* HTTPClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E970E52850272800FE5AE3 /* HTTPClientStub.swift */; };
 		43E970E82850280900FE5AE3 /* InMemoryFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E970E72850280900FE5AE3 /* InMemoryFeedStore.swift */; };
 		43EC03B22851834E008F6608 /* UIImage+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EC03B12851834E008F6608 /* UIImage+TestHelpers.swift */; };
+		43EC03B62852DF29008F6608 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EC03B52852DF29008F6608 /* UIView+TestHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,6 +126,7 @@
 		43E970E52850272800FE5AE3 /* HTTPClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientStub.swift; sourceTree = "<group>"; };
 		43E970E72850280900FE5AE3 /* InMemoryFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryFeedStore.swift; sourceTree = "<group>"; };
 		43EC03B12851834E008F6608 /* UIImage+TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+TestHelpers.swift"; path = "../../../EssentialFeed/EssentialFeediOSTests/Helpers/UIImage+TestHelpers.swift"; sourceTree = "<group>"; };
+		43EC03B52852DF29008F6608 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,6 +237,7 @@
 				43B3C7302849AB11001CDEF8 /* FeedViewController+TestHelpers.swift */,
 				43E970E52850272800FE5AE3 /* HTTPClientStub.swift */,
 				43E970E72850280900FE5AE3 /* InMemoryFeedStore.swift */,
+				43EC03B52852DF29008F6608 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				43E970E62850272800FE5AE3 /* HTTPClientStub.swift in Sources */,
 				43B3C6D1282E02EF001CDEF8 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				43B3C72B2849A956001CDEF8 /* UIRefreshControl+TestHelpers.swift in Sources */,
+				43EC03B62852DF29008F6608 /* UIView+TestHelpers.swift in Sources */,
 				43B3C6E228311973001CDEF8 /* FeedLoaderStub.swift in Sources */,
 				43B3C733284EE918001CDEF8 /* FeedAcceptanceTests.swift in Sources */,
 				43B3C7212849A667001CDEF8 /* FeedUIIntegrationTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -72,6 +72,23 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        
+        assertThat(sut, isRendering: [])
+        
+        loader.completeLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiateFeedLoad()
+        loader.completeLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doseNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage(description: "A Description", location: "location")
         let (sut, loader) = makeSUT()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -12,8 +12,7 @@ import EssentialFeed
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController,  isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.tableView.enforceLayoutCycle()
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -12,6 +12,9 @@ import EssentialFeed
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController,  isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 10/06/22.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -18,6 +18,8 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     
     @IBOutlet private(set) public var errorView: ErrorView?
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -39,6 +41,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -73,11 +76,14 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }
 


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls `didEndDisplayingCell` for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.